### PR TITLE
README: fixed typo and added reference to GEM workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # GEM 2019 
+Repository for tutorial, notes, and Jupyter notebooks. Primarily a resource developed for the 2019 NSF-funded Geospace Environment Modeling (GEM) workshop.
 
-Repository for tutorial, notes, and Jupyter notebooks.
-
-# Instally Python
+# Installing Python
 A brief description of installing Python on Windows, Mac, and Linux can be found [here][1].
 
 # Jupyter Notebook


### PR DESCRIPTION
Simple PR here.

I've just fixed a typo in the README, and added an opening sentence that refers to the Geospace Environment Modeling workshop. Hopefully that'll demystify this for people who find this while browsing, as well as adding search terms that will help relevant folks stumble across it.